### PR TITLE
64bit compatible

### DIFF
--- a/src/materialModels/continuumPlasticity/continuumPlasticity.h
+++ b/src/materialModels/continuumPlasticity/continuumPlasticity.h
@@ -635,7 +635,7 @@ void continuumPlasticity<dim>::getElementalValues(FEValues<dim>& fe_values,
   enhStrain.staticCondensationData[cellID].reset();
 
   //Vector relating local to global degree of freedom numbers
-  std::vector<unsigned int> local_dof_indices(dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
   //Local displacement vector
   Vector<double> Ulocal(dofs_per_cell);
 
@@ -692,7 +692,7 @@ template <int dim>
 void continuumPlasticity<dim>::updateAfterIteration()
 {
   //After solving for the nodal values, calculate the enhanced degrees of freedom.
-  std::vector<unsigned int> local_dof_indices(this->FE.dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(this->FE.dofs_per_cell);
   Vector<double> dUlocal(this->FE.dofs_per_cell);
   typename DoFHandler<dim>::active_cell_iterator cell = this->dofHandler.begin_active(),
     endc = this->dofHandler.end();

--- a/src/materialModels/crystalPlasticity/getElementalValues.cc
+++ b/src/materialModels/crystalPlasticity/getElementalValues.cc
@@ -19,7 +19,7 @@ void crystalPlasticity<dim>::getElementalValues(FEValues<dim>& fe_values,
 		}
 
 		unsigned int cellID = fe_values.get_cell()->user_index();
-		std::vector<unsigned int> local_dof_indices(dofs_per_cell);
+		std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 		Vector<double> Ulocal(dofs_per_cell);
 
 		typename DoFHandler<dim>::active_cell_iterator cell(& this->triangulation,

--- a/src/materialModels/crystalPlasticity/updateAfterIncrement.cc
+++ b/src/materialModels/crystalPlasticity/updateAfterIncrement.cc
@@ -24,7 +24,7 @@ void crystalPlasticity<dim>::updateAfterIncrement()
 	FEValues<dim> fe_values(this->FE, quadrature, update_quadrature_points | update_gradients | update_JxW_values);
 	const unsigned int num_quad_points = quadrature.size();
 	const unsigned int   dofs_per_cell = this->FE.dofs_per_cell;
-	std::vector<unsigned int> local_dof_indices(dofs_per_cell);
+	std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 	if (this->userInputs.flagTaylorModel){
 		if(initCalled == false){
 			if(this->userInputs.enableAdvancedTwinModel){


### PR DESCRIPTION
This branch resolves the type incompatibilities that arise when PRISMS-Plasticity is compiled with a deal.II installation that has 64 bit indices are enabled for large computations.