### PR TITLE
V1.4.0 fixes

### DIFF
--- a/applications/crystalPlasticity/CMakeLists.txt
+++ b/applications/crystalPlasticity/CMakeLists.txt
@@ -73,3 +73,6 @@ elseif(${CMAKE_BUILD_TYPE} STREQUAL "DebugRelease")
 else()
 	TARGET_LINK_LIBRARIES(main ${CMAKE_SOURCE_DIR}/../../libprisms_cp_debug.a)
 endif()
+
+set_target_properties(main PROPERTIES OUTPUT_NAME "crystalPlasticity")
+install(TARGETS main RUNTIME)

--- a/applications/crystalPlasticity/main.cc
+++ b/applications/crystalPlasticity/main.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 
 // Using namespace std gets GCC confused in the Boost geometry point_xy.hpp
+// See also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110636
 //using namespace std;
 
 #include "../../include/crystalPlasticity.h"

--- a/applications/crystalPlasticity/main.cc
+++ b/applications/crystalPlasticity/main.cc
@@ -3,7 +3,9 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
-using namespace std;
+
+// Using namespace std gets GCC confused in the Boost geometry point_xy.hpp
+//using namespace std;
 
 #include "../../include/crystalPlasticity.h"
 

--- a/src/ellipticBVP/applyInitialConditions.cc
+++ b/src/ellipticBVP/applyInitialConditions.cc
@@ -7,7 +7,7 @@ void ellipticBVP<dim>::applyInitialConditions(){
   //pcout << "applying the default zero initial condition\n";
   //default method to apply zero initial conditions on all fields
   VectorTools::interpolate (dofHandler,
-			    ZeroFunction<dim>(dim),
+			    dealii::Functions::ZeroFunction<dim>(dim),
 			    solution);
 }
 #include "../../include/ellipticBVP_template_instantiations.h"


### PR DESCRIPTION
Trying to install Crystal Plasticity on the HPC cluster at the University of Duisburg-Essen I ran into a few small issues. I have fixed those with the changes included in this pull request. Two of the issues occurred with the GNU compilers, version 11.4. Both of them are related to namespaces (one where the GNU compilers don't pick the right namespace automatically for the function that zeros a data structure, and the other where the GNU compilers confuse std::set and the set member of Boost's point_xy class if "using std" is used in the main program). 

The other issue involves a change to the CMake setup. I am installing the Crystal Plasticity for the users on our cluster. For that I want to install the application in a suitable place and provide our users with a Module they can load. As the application is installed in a directory outside of the source code tree I think "crystalPlasticity" is a better name than "main".

I hope you are willing to consider adopting these changes.