### PR TITLE
Removed using namespace std header from main.cc files

### DIFF
--- a/applications/continuumPlasticity/main.cc
+++ b/applications/continuumPlasticity/main.cc
@@ -3,7 +3,6 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
-using namespace std;
 
 #include "../../include/continuumPlasticity.h"
 

--- a/applications/crystalPlasticity/main.cc
+++ b/applications/crystalPlasticity/main.cc
@@ -3,7 +3,6 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
-using namespace std;
 
 #include "../../include/crystalPlasticity.h"
 


### PR DESCRIPTION
This avoids conflict between the std::set  function and this->template set<1>(v); from the boost library.
